### PR TITLE
flutter 3.24.1のpackage:testのバージョンと合うように調整

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 # Add regular dependencies here.
 dependencies:
   collection: ^1.18.0
-  test: ^1.25.8
+  test: ">=1.24.0 <=1.25.8"
 
 dev_dependencies:
   lints: ^3.0.0


### PR DESCRIPTION
## 背景

FlutterTemplate（のフォーク）のFlutterを3.22.1から3.24.1にアップグレードすると以下のように test パッケージのバージョン管理で競合エラーが出てしまいました。

```
Because test >=1.24.0 <1.24.3 depends on matcher >=0.12.15 <0.12.16 and test >=1.24.3 <1.24.4 depends on test_api 0.6.0, test
  >=1.24.0 <1.24.4 requires matcher >=0.12.15 <0.12.16 or test_api 0.6.0.
And because test >=1.24.4 <1.25.0 depends on test_api 0.6.1, test >=1.24.0 <1.25.0 requires matcher >=0.12.15 <0.12.16 or
  test_api 0.6.0 or 0.6.1.
And because test >=1.25.0 <1.25.3 depends on test_api 0.7.0 and every version of flutter_test from sdk depends on matcher
  0.12.16+1, if test >=1.24.0 <1.25.3 and flutter_test from sdk then test_api 0.6.0 or 0.6.1 or 0.7.0.
And because every version of flutter_test from sdk depends on test_api 0.7.2 and every version of dart_fsm from git depends on
  test >=1.24.0 <1.25.2, flutter_test from sdk is incompatible with dart_fsm from git.
So, because flutter_template depends on both dart_fsm from git and flutter_test from sdk, version solving failed.
```

## 変更内容

package:test 1.25.8以上だとFlutter 3.24.1 内蔵の test のバージョンより新しいため、 1.24.0以上、1.25.8以下の指定にした。