### PR TITLE
fix: Prevent dispatching actions after state machine is closed

### DIFF
--- a/lib/src/state_machine/implementation/state_machine_impl.dart
+++ b/lib/src/state_machine/implementation/state_machine_impl.dart
@@ -67,6 +67,9 @@ class StateMachineImpl<STATE extends Object, ACTION extends Object>
 
   @override
   void dispatch(ACTION action) {
+    if (_controller.isClosed) {
+      return;
+    }
     beforeJob(action);
     final transition = findTransition(_state, action);
     if (transition is Valid) {

--- a/test/state_machine_close_test.dart
+++ b/test/state_machine_close_test.dart
@@ -60,5 +60,25 @@ void main() {
 
       expect(isCloseCalled, isTrue);
     });
+
+    test('dispatch after state machine is closed should be ignored', () {
+      final stateMachine = createStateMachine(
+        initialState: const TestStateA(),
+        graphBuilder: simpleTestStateGraph,
+      )
+        ..close()
+        ..dispatch(const TestActionA());
+
+      expect(stateMachine.state, const TestStateA());
+    });
+
+    test('dispatch after state machine is closed should not throw error', () {
+      final stateMachine = createStateMachine(
+        initialState: const TestStateA(),
+        graphBuilder: simpleTestStateGraph,
+      )..close();
+
+      expect(() => stateMachine.dispatch(const TestActionA()), returnsNormally);
+    });
   });
 }


### PR DESCRIPTION
# Pull Request Description
<!-- Briefly describe what this pull request aims to accomplish. -->
Improve StateMachine to ignore dispatched actions after it has been closed, preventing errors.

<!-- List the main changes, new features, or bug fixes. -->
When the dispatch method is called after a StateMachine is closed, it will return early to prevent errors and ensure predictable behavior.

## Related Issues
<!-- If this pull request addresses any issues, link to the issue(s) here. -->
<!-- Example: Fixes #123 -->
Fixes #N/A

## Changes Proposed
<!-- Describe the changes made in detail. -->
<!-- Include code changes, documentation updates, bug fixes, new features, etc. -->
<!-- Example: -->
<!-- - Added new feature -->
<!-- - Fixed a bug -->
<!-- - Updated documentation -->
1. Add early return in StateMachineImpl's dispatch method when the controller is closed
2. Add test cases to verify the behavior of dispatch after StateMachine is closed
## Testing Checklist
<!-- List the tests to confirm the changes work as intended. -->
<!-- Example: -->
<!-- - [ ] Verify the new function works as expected -->
<!-- - [ ] Performance test with large dataset -->
- [x] Test that dispatch after StateMachine is closed does not cause state changes
- [x] Test that dispatch after StateMachine is closed does not throw errors
- [x] Verify all existing tests pass

## Checklist
<!-- Ensure all items on this checklist are completed. -->
- [x] Code follows the project's coding style
- [x] Documentation has been updated if necessary
- [x] Tests have been added or updated if necessary

## Additional Comments
<!-- Provide any additional information or questions regarding this pull request. -->
This PR addresses an important edge case in StateMachine lifecycle management. It ensures that dispatches to a closed StateMachine are safely handled, preventing unexpected errors. Additionally, it clearly defines the behavior after a StateMachine's lifecycle has ended, making it more predictable.

---
_This project is licensed under the [BSD-3-Clause License](../LICENSE)._
