### PR TITLE
docs: Fix createStateMachine argument names

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -207,7 +207,7 @@ final class SampleSideEffect
 final stateMachine = createStateMachine(
   initialState: const SampleStateInitial(),
   graphBuilder: stateGraph,
-  sideEffectCreator: SampleSideEffectCreator(apiClient),
+  sideEffectCreators: [SampleSideEffectCreator(apiClient)],
 );
 ```
 これでApiを呼び出す副作用が有限オートマトンに登録されました。
@@ -255,8 +255,8 @@ final class SampleSubscription
 final stateMachine = createStateMachine(
   initialState: const SampleStateInitial(),
   graphBuilder: stateGraph,
-  sideEffectCreator: SampleSideEffectCreator(apiClient),
-  subscription: SampleSubscription(webSocketClient),
+  sideEffectCreators: [SampleSideEffectCreator(apiClient)],
+  subscriptions: [SampleSubscription(webSocketClient)],
 );
 ```
 これでWebSocketClientからデータを受け取り、データをもとにSampleActionUpdateを発行するSubscriptionが有限オートマトンに登録されました。

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Now that the `SampleSideEffect` to make API calls and the `SampleSideEffectCreat
 final stateMachine = createStateMachine(
   initialState: const SampleStateInitial(),
   graphBuilder: stateGraph,
-  sideEffectCreator: SampleSideEffectCreator(apiClient),
+  sideEffectCreators: [SampleSideEffectCreator(apiClient)],
 );
 ```
 This registers the side effect to make API calls with the finite state machine. Each time a state transition occurs, the `SampleSideEffectCreator` is called, and if the action that caused the transition is `Fetch`, a `SampleSideEffect` is generated, and the API is called.
@@ -240,8 +240,8 @@ This defines a `Subscription` to receive data from the `WebSocketClient` and iss
 final stateMachine = createStateMachine(
   initialState: const SampleStateInitial(),
   graphBuilder: stateGraph,
-  sideEffectCreator: SampleSideEffectCreator(apiClient),
-  subscription: SampleSubscription(webSocketClient),
+  sideEffectCreators: [SampleSideEffectCreator(apiClient)],
+  subscriptions: [SampleSubscription(webSocketClient)],
 );
 ```
 This registers the `Subscription` with the finite state machine to receive data from the `WebSocketClient` and issue `SampleActionUpdate` based on the data.


### PR DESCRIPTION
# Pull Request Description

The examples in the README.md currently use sideEffectCreator and subscription as arguments for createStateMachine. The actual parameter names are sideEffectCreators and subscriptions so the example code throws an error. The stateMachineCreator also expects SideEffectCreators and Subscriptions as a list.

This pull requests fixes the argument name and passes the SideEffectCreator / Subscription in a list.

## Related Issues
none

## Changes Proposed
1. Update documentation

## Testing Checklist
- [x] Try executing the updated example code

## Checklist
<!-- Ensure all items on this checklist are completed. -->
- [x] Code follows the project's coding style
- [x] Documentation has been updated if necessary
- [x] Tests have been added or updated if necessary

## Additional Comments