### PR TITLE
Add a declarative StateMachine test DSL

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -317,6 +317,9 @@ runner は `states x actions` のすべての組み合わせに対する coverag
 `transitionExpectationIs(after: ..., eventually: ...)` を使います。外部依存は
 `createMocks` で渡し、`arrange` で準備し、`verify` で呼び出しを検証できます。
 
+`StateMachineTester`、`SMAssertObject`、`TesterStateMachine` は非推奨です。
+既存テストは `runStateMachineTestCases` へ移行してください。
+
 ## 使用例
 ```dart
 import 'package:dart_fsm/dart_fsm.dart';

--- a/README-ja.md
+++ b/README-ja.md
@@ -262,8 +262,60 @@ final stateMachine = createStateMachine(
 これでWebSocketClientからデータを受け取り、データをもとにSampleActionUpdateを発行するSubscriptionが有限オートマトンに登録されました。
 
 ### 有限オートマトンを用いたテストの実装
-TODO
 
+`dart_fsm_test_tools.dart` が公開するテスト DSL を使うと、状態遷移テストを
+Given-When-Then 形式で記述できます。各 state/action の組み合わせごとに実物の
+`StateMachine` を新しく生成し、状態値と `stateStream` の emission を検証します。
+
+```dart
+import 'package:dart_fsm/dart_fsm.dart';
+import 'package:dart_fsm/dart_fsm_test_tools.dart';
+
+void main() {
+  runStateMachineTestCases<SampleState, SampleAction, Object>(
+    name: 'SampleStateMachine',
+    createMocks: Object.new,
+    createStateMachine: (_, initialState) => createStateMachine(
+      graphBuilder: stateGraph,
+      initialState: initialState,
+    ),
+    states: const [
+      SampleStateInitial(),
+      SampleStateLoading(),
+    ],
+    actions: const [
+      SampleActionFetch(),
+    ],
+    cases: [
+      whenInitialStateIs(
+        const SampleStateInitial(),
+        actions: [
+          ifDispatched(
+            const SampleActionFetch(),
+            then: transitionExpectationIs(
+              after: const SampleStateLoading(),
+            ),
+          ),
+        ],
+      ),
+      whenInitialStateIs(
+        const SampleStateLoading(),
+        actions: [
+          ifDispatched(
+            const SampleActionFetch(),
+            then: expectInvalidTransition(),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+```
+
+runner は `states x actions` のすべての組み合わせに対する coverage test も
+登録します。非同期 SideEffect が後続遷移を起こす場合は
+`transitionExpectationIs(after: ..., eventually: ...)` を使います。外部依存は
+`createMocks` で渡し、`arrange` で準備し、`verify` で呼び出しを検証できます。
 
 ## 使用例
 ```dart

--- a/README-ja.md
+++ b/README-ja.md
@@ -316,6 +316,7 @@ runner は `states x actions` のすべての組み合わせに対する coverag
 登録します。非同期 SideEffect が後続遷移を起こす場合は
 `transitionExpectationIs(after: ..., eventually: ...)` を使います。外部依存は
 `createMocks` で渡し、`arrange` で準備し、`verify` で呼び出しを検証できます。
+どちらのコールバックも非同期処理を返すことができ、runnerは完了を待ちます。
 
 `StateMachineTester`、`SMAssertObject`、`TesterStateMachine` は非推奨です。
 既存テストは `runStateMachineTestCases` へ移行してください。

--- a/README.md
+++ b/README.md
@@ -302,7 +302,8 @@ The runner adds a coverage test for every value in the `states x actions`
 matrix. Use `transitionExpectationIs(after: ..., eventually: ...)` when an
 asynchronous side effect causes a follow-up transition. External dependencies
 can be supplied by `createMocks`, prepared with `arrange`, and checked with
-`verify`.
+`verify`. Both callbacks may be asynchronous; the runner waits for them to
+complete.
 
 `StateMachineTester`, `SMAssertObject`, and `TesterStateMachine` are
 deprecated. Existing tests should migrate to `runStateMachineTestCases`.

--- a/README.md
+++ b/README.md
@@ -304,6 +304,9 @@ asynchronous side effect causes a follow-up transition. External dependencies
 can be supplied by `createMocks`, prepared with `arrange`, and checked with
 `verify`.
 
+`StateMachineTester`, `SMAssertObject`, and `TesterStateMachine` are
+deprecated. Existing tests should migrate to `runStateMachineTestCases`.
+
 ## Example Usage
 ```dart
 import 'package:dart_fsm/dart_fsm.dart';

--- a/README.md
+++ b/README.md
@@ -247,8 +247,62 @@ final stateMachine = createStateMachine(
 This registers the `Subscription` with the finite state machine to receive data from the `WebSocketClient` and issue `SampleActionUpdate` based on the data.
 
 ### Implementing Tests Using Finite State Machines
-TODO
 
+The test DSL exported by `dart_fsm_test_tools.dart` describes transition
+tests in a Given-When-Then form. It creates a fresh, real `StateMachine` for
+each state/action pair and verifies both state values and `stateStream`
+emissions.
+
+```dart
+import 'package:dart_fsm/dart_fsm.dart';
+import 'package:dart_fsm/dart_fsm_test_tools.dart';
+
+void main() {
+  runStateMachineTestCases<SampleState, SampleAction, Object>(
+    name: 'SampleStateMachine',
+    createMocks: Object.new,
+    createStateMachine: (_, initialState) => createStateMachine(
+      graphBuilder: stateGraph,
+      initialState: initialState,
+    ),
+    states: const [
+      SampleStateInitial(),
+      SampleStateLoading(),
+    ],
+    actions: const [
+      SampleActionFetch(),
+    ],
+    cases: [
+      whenInitialStateIs(
+        const SampleStateInitial(),
+        actions: [
+          ifDispatched(
+            const SampleActionFetch(),
+            then: transitionExpectationIs(
+              after: const SampleStateLoading(),
+            ),
+          ),
+        ],
+      ),
+      whenInitialStateIs(
+        const SampleStateLoading(),
+        actions: [
+          ifDispatched(
+            const SampleActionFetch(),
+            then: expectInvalidTransition(),
+          ),
+        ],
+      ),
+    ],
+  );
+}
+```
+
+The runner adds a coverage test for every value in the `states x actions`
+matrix. Use `transitionExpectationIs(after: ..., eventually: ...)` when an
+asynchronous side effect causes a follow-up transition. External dependencies
+can be supplied by `createMocks`, prepared with `arrange`, and checked with
+`verify`.
 
 ## Example Usage
 ```dart

--- a/lib/dart_fsm_test_tools.dart
+++ b/lib/dart_fsm_test_tools.dart
@@ -3,5 +3,6 @@
 // found in the LICENSE file.
 
 export 'src/tester/mock_state_machine.dart';
+export 'src/tester/state_machine_test_dsl.dart';
 export 'src/tester/state_machine_tester.dart';
 export 'src/tester/tester_state_machine.dart';

--- a/lib/src/tester/state_machine_test_dsl.dart
+++ b/lib/src/tester/state_machine_test_dsl.dart
@@ -29,14 +29,20 @@ typedef StateMachineTestCases<STATE extends Object, ACTION extends Object,
 /// Arranges external dependencies before an action is dispatched.
 ///
 /// Keep repository stubbing here so that the transition expectation remains
-/// separate from dependency setup.
-typedef MockArrange<MOCKS extends Object> = void Function(MOCKS mocks);
+/// separate from dependency setup. The runner waits for asynchronous setup to
+/// complete before creating the StateMachine.
+typedef MockArrange<MOCKS extends Object> = FutureOr<void> Function(
+  MOCKS mocks,
+);
 
 /// Verifies external dependency interactions after a transition settles.
 ///
 /// Keep repository verification here so that side effects are asserted
-/// separately from state transitions.
-typedef MockVerify<MOCKS extends Object> = void Function(MOCKS mocks);
+/// separately from state transitions. The runner waits for asynchronous
+/// verification to complete before cleaning up the test case.
+typedef MockVerify<MOCKS extends Object> = FutureOr<void> Function(
+  MOCKS mocks,
+);
 
 /// Runs custom setup or teardown around each generated test case.
 typedef StateMachineTestHook = FutureOr<void> Function();
@@ -49,6 +55,9 @@ typedef StateMachineTestHook = FutureOr<void> Function();
 ///
 /// It also registers a coverage test that fails when any `states x actions`
 /// pair is missing from [cases], or when unexpected cases exist.
+///
+/// [afterEach] is invoked for every generated transition test even when setup,
+/// execution, or earlier cleanup fails.
 void runStateMachineTestCases<STATE extends Object, ACTION extends Object,
     MOCKS extends Object>({
   required String name,
@@ -74,13 +83,16 @@ void runStateMachineTestCases<STATE extends Object, ACTION extends Object,
         for (final actionCase in stateCase._actions) {
           final description = actionCase._describe(stateCase._initial);
           test(description, () async {
-            await beforeEach?.call();
             fsm.StateMachine<STATE, ACTION>? stateMachine;
             _StateStreamProbe<STATE>? stateStreamProbe;
 
             try {
+              await beforeEach?.call();
               final mocks = createMocks();
-              actionCase._arrange?.call(mocks);
+              final arrange = actionCase._arrange;
+              if (arrange != null) {
+                await arrange(mocks);
+              }
               stateMachine = createStateMachine(mocks, stateCase._initial);
               stateStreamProbe = _StateStreamProbe<STATE>(
                 stateMachine.stateStream,
@@ -106,11 +118,20 @@ void runStateMachineTestCases<STATE extends Object, ACTION extends Object,
                 actionCase._finallyState(stateCase._initial),
                 reason: context,
               );
-              actionCase._verify?.call(mocks);
+              final verify = actionCase._verify;
+              if (verify != null) {
+                await verify(mocks);
+              }
             } finally {
-              await stateStreamProbe?.cancel();
-              stateMachine?.close();
-              await afterEach?.call();
+              try {
+                await stateStreamProbe?.cancel();
+              } finally {
+                try {
+                  stateMachine?.close();
+                } finally {
+                  await afterEach?.call();
+                }
+              }
             }
           });
         }

--- a/lib/src/tester/state_machine_test_dsl.dart
+++ b/lib/src/tester/state_machine_test_dsl.dart
@@ -1,0 +1,444 @@
+// Copyright (c) 2024, teamLab inc.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:dart_fsm/dart_fsm.dart' as fsm;
+import 'package:test/test.dart';
+
+/// Creates a real StateMachine for one transition test case.
+///
+/// The runner passes a fresh mock bundle and the source state for the case.
+/// Implementations should return the production StateMachine with that source
+/// state as its initial state.
+typedef StateMachineFactory<STATE extends Object, ACTION extends Object,
+        MOCKS extends Object>
+    = fsm.StateMachine<STATE, ACTION> Function(
+  MOCKS mocks,
+  STATE initialState,
+);
+
+/// A list of transition specifications for a StateMachine.
+///
+/// Each entry describes all action expectations for one source state.
+typedef StateMachineTestCases<STATE extends Object, ACTION extends Object,
+        MOCKS extends Object>
+    = List<StateCase<STATE, ACTION, MOCKS>>;
+
+/// Arranges external dependencies before an action is dispatched.
+///
+/// Keep repository stubbing here so that the transition expectation remains
+/// separate from dependency setup.
+typedef MockArrange<MOCKS extends Object> = void Function(MOCKS mocks);
+
+/// Verifies external dependency interactions after a transition settles.
+///
+/// Keep repository verification here so that side effects are asserted
+/// separately from state transitions.
+typedef MockVerify<MOCKS extends Object> = void Function(MOCKS mocks);
+
+/// Runs custom setup or teardown around each generated test case.
+typedef StateMachineTestHook = FutureOr<void> Function();
+
+/// Registers exhaustive Given-When-Then transition tests for a StateMachine.
+///
+/// The runner creates a fresh real StateMachine for each state/action pair,
+/// dispatches the action, verifies the immediate state, waits for the expected
+/// state stream emissions, and finally verifies the settled state.
+///
+/// It also registers a coverage test that fails when any `states x actions`
+/// pair is missing from [cases], or when unexpected cases exist.
+void runStateMachineTestCases<STATE extends Object, ACTION extends Object,
+    MOCKS extends Object>({
+  required String name,
+  required MOCKS Function() createMocks,
+  required StateMachineFactory<STATE, ACTION, MOCKS> createStateMachine,
+  required List<STATE> states,
+  required List<ACTION> actions,
+  required StateMachineTestCases<STATE, ACTION, MOCKS> cases,
+  StateMachineTestHook? beforeEach,
+  StateMachineTestHook? afterEach,
+}) {
+  group(name, () {
+    test('covers every state/action pair', () {
+      _expectAllTransitionsCovered(
+        states: states,
+        actions: actions,
+        cases: cases,
+      );
+    });
+
+    for (final stateCase in cases) {
+      group(_stateLabel(stateCase._initial), () {
+        for (final actionCase in stateCase._actions) {
+          final description = actionCase._describe(stateCase._initial);
+          test(description, () async {
+            await beforeEach?.call();
+            fsm.StateMachine<STATE, ACTION>? stateMachine;
+            _StateStreamProbe<STATE>? stateStreamProbe;
+
+            try {
+              final mocks = createMocks();
+              actionCase._arrange?.call(mocks);
+              stateMachine = createStateMachine(mocks, stateCase._initial);
+              stateStreamProbe = _StateStreamProbe<STATE>(
+                stateMachine.stateStream,
+              );
+              final context = _failureContext(
+                beforeState: stateCase._initial,
+                action: actionCase._dispatch,
+                description: description,
+              );
+              stateMachine.dispatch(actionCase._dispatch);
+
+              expect(
+                stateMachine.state,
+                actionCase._afterState(stateCase._initial),
+                reason: context,
+              );
+              await stateStreamProbe.expectEmittedStates(
+                actionCase._emittedStates(stateCase._initial),
+                context,
+              );
+              expect(
+                stateMachine.state,
+                actionCase._finallyState(stateCase._initial),
+                reason: context,
+              );
+              actionCase._verify?.call(mocks);
+            } finally {
+              await stateStreamProbe?.cancel();
+              stateMachine?.close();
+              await afterEach?.call();
+            }
+          });
+        }
+      });
+    }
+  });
+}
+
+/// Starts a transition specification from the given source state.
+///
+/// Use this as the Given part of a StateMachine test case. The [actions] list
+/// should include every action that belongs to the public action set under
+/// test, including invalid transitions.
+StateCase<STATE, ACTION, MOCKS> whenInitialStateIs<STATE extends Object,
+    ACTION extends Object, MOCKS extends Object>(
+  STATE initial, {
+  required List<ActionCase<STATE, ACTION, MOCKS>> actions,
+}) {
+  return StateCase._(
+    initial: initial,
+    actions: actions,
+  );
+}
+
+/// Describes the expectation for dispatching one action.
+///
+/// Use this as the When part of a StateMachine test case. [then] describes the
+/// state transition expectation, [arrange] arranges external dependencies, and
+/// [verify] checks side-effect interactions after the transition has settled.
+ActionCase<STATE, ACTION, MOCKS> ifDispatched<STATE extends Object,
+    ACTION extends Object, MOCKS extends Object>(
+  ACTION action, {
+  required TransitionExpectation<STATE> then,
+  MockArrange<MOCKS>? arrange,
+  MockVerify<MOCKS>? verify,
+}) {
+  return ActionCase._(
+    dispatch: action,
+    expectation: then,
+    arrange: arrange,
+    verify: verify,
+  );
+}
+
+/// Expects a valid transition to [after], and optionally to [eventually].
+///
+/// [after] is asserted immediately after dispatch. [eventually] is asserted
+/// after asynchronous side effects have emitted their follow-up state.
+TransitionExpectation<STATE> transitionExpectationIs<STATE extends Object>({
+  required STATE after,
+  STATE? eventually,
+}) {
+  return TransitionExpectation._transitionTo(
+    afterState: after,
+    finallyState: eventually,
+  );
+}
+
+/// Expects the dispatched action to be invalid for the source state.
+///
+/// Invalid transitions must emit no states and must leave the StateMachine in
+/// the original source state.
+TransitionExpectation<STATE> expectInvalidTransition<STATE extends Object>() =>
+    TransitionExpectation<STATE>._invalid();
+
+void _expectAllTransitionsCovered<STATE extends Object, ACTION extends Object,
+    MOCKS extends Object>({
+  required List<STATE> states,
+  required List<ACTION> actions,
+  required StateMachineTestCases<STATE, ACTION, MOCKS> cases,
+}) {
+  final errors = <String>[];
+  final expectedStates = states.toSet();
+  final expectedActions = actions.toSet();
+  final stateCasesByState = <STATE, StateCase<STATE, ACTION, MOCKS>>{};
+
+  for (final stateCase in cases) {
+    stateCasesByState[stateCase._initial] = stateCase;
+  }
+
+  for (final state in states) {
+    final stateCase = stateCasesByState[state];
+    if (stateCase == null) {
+      errors.add('missing state case: $state');
+      continue;
+    }
+
+    final actionCases = <ACTION>{};
+    for (final actionCase in stateCase._actions) {
+      actionCases.add(actionCase._dispatch);
+      if (!expectedActions.contains(actionCase._dispatch)) {
+        errors.add('unexpected action case: $state + ${actionCase._dispatch}');
+      }
+    }
+
+    for (final action in actions) {
+      if (!actionCases.contains(action)) {
+        errors.add('missing action case: $state + $action');
+      }
+    }
+  }
+
+  for (final stateCase in cases) {
+    if (!expectedStates.contains(stateCase._initial)) {
+      errors.add('unexpected state case: ${stateCase._initial}');
+    }
+  }
+
+  if (errors.isEmpty) {
+    return;
+  }
+
+  fail(
+    '''
+StateMachine transition test cases are not exhaustive.
+${errors.join('\n')}
+''',
+  );
+}
+
+/// Opaque transition specifications for one source state.
+///
+/// Prefer creating instances through [whenInitialStateIs] so that tests keep a
+/// consistent Given-When-Then shape.
+final class StateCase<STATE extends Object, ACTION extends Object,
+    MOCKS extends Object> {
+  const StateCase._({
+    required STATE initial,
+    required List<ActionCase<STATE, ACTION, MOCKS>> actions,
+  })  : _initial = initial,
+        _actions = actions;
+
+  final STATE _initial;
+  final List<ActionCase<STATE, ACTION, MOCKS>> _actions;
+}
+
+/// Opaque transition expectation for one dispatched action.
+///
+/// Prefer creating instances through [ifDispatched] so that arrangement,
+/// transition expectations, and verification remain in the same order in every
+/// test case.
+final class ActionCase<STATE extends Object, ACTION extends Object,
+    MOCKS extends Object> {
+  const ActionCase._({
+    required ACTION dispatch,
+    required TransitionExpectation<STATE> expectation,
+    MockArrange<MOCKS>? arrange,
+    MockVerify<MOCKS>? verify,
+  })  : _dispatch = dispatch,
+        _expectation = expectation,
+        _arrange = arrange,
+        _verify = verify;
+
+  final ACTION _dispatch;
+  final TransitionExpectation<STATE> _expectation;
+  final MockArrange<MOCKS>? _arrange;
+  final MockVerify<MOCKS>? _verify;
+
+  String _describe(STATE beforeState) {
+    return switch (_expectation) {
+      _InvalidTransitionExpectation<STATE>() =>
+        '$_dispatch -> invalid transition',
+      _TransitionToExpectation<STATE>() =>
+        '$_dispatch -> ${_stateLabel(_afterState(beforeState))}'
+            '${_eventuallyDescription(beforeState)}',
+    };
+  }
+
+  STATE _afterState(STATE beforeState) {
+    return _expectation._resolveAfterState(beforeState);
+  }
+
+  STATE _finallyState(STATE beforeState) {
+    return _expectation._resolveFinallyState(beforeState);
+  }
+
+  List<STATE> _emittedStates(STATE beforeState) {
+    return _expectation._resolveEmittedStates(beforeState);
+  }
+
+  String _eventuallyDescription(STATE beforeState) {
+    final after = _afterState(beforeState);
+    final eventually = _finallyState(beforeState);
+    if (after == eventually) {
+      return '';
+    }
+
+    return ' -> ${_stateLabel(eventually)}';
+  }
+}
+
+/// Opaque expected transition result for a dispatched action.
+///
+/// Use [transitionExpectationIs] for valid transitions and
+/// [expectInvalidTransition] for invalid transitions. The concrete expectation
+/// variants are private so tests do not depend on runner internals.
+sealed class TransitionExpectation<STATE extends Object> {
+  const TransitionExpectation._();
+
+  const factory TransitionExpectation._invalid() =
+      _InvalidTransitionExpectation<STATE>;
+
+  const factory TransitionExpectation._transitionTo({
+    required STATE afterState,
+    STATE? finallyState,
+  }) = _TransitionToExpectation<STATE>;
+
+  STATE _resolveAfterState(STATE beforeState) {
+    return switch (this) {
+      _InvalidTransitionExpectation<STATE>() => beforeState,
+      _TransitionToExpectation<STATE>(:final afterState) => afterState,
+    };
+  }
+
+  STATE _resolveFinallyState(STATE beforeState) {
+    return switch (this) {
+      _InvalidTransitionExpectation<STATE>() => beforeState,
+      _TransitionToExpectation<STATE>(
+        :final afterState,
+        :final finallyState,
+      ) =>
+        finallyState ?? afterState,
+    };
+  }
+
+  List<STATE> _resolveEmittedStates(STATE beforeState) {
+    return switch (this) {
+      _InvalidTransitionExpectation<STATE>() => <STATE>[],
+      _TransitionToExpectation<STATE>(
+        :final afterState,
+        :final finallyState,
+      ) =>
+        [
+          afterState,
+          if (finallyState != null && finallyState != afterState) finallyState,
+        ],
+    };
+  }
+}
+
+final class _InvalidTransitionExpectation<STATE extends Object>
+    extends TransitionExpectation<STATE> {
+  const _InvalidTransitionExpectation() : super._();
+}
+
+final class _TransitionToExpectation<STATE extends Object>
+    extends TransitionExpectation<STATE> {
+  const _TransitionToExpectation({
+    required this.afterState,
+    this.finallyState,
+  }) : super._();
+
+  final STATE afterState;
+  final STATE? finallyState;
+}
+
+const _stateStreamExpectationTimeout = Duration(milliseconds: 100);
+
+final class _StateStreamProbe<STATE extends Object> {
+  _StateStreamProbe(Stream<STATE> stateStream) {
+    _subscription = stateStream.listen((state) {
+      _emittedStates.add(state);
+      _completeWaiter();
+    });
+  }
+
+  final _emittedStates = <STATE>[];
+  Completer<void>? _waiter;
+  late final StreamSubscription<STATE> _subscription;
+
+  Future<void> expectEmittedStates(
+    List<STATE> expectedStates,
+    String context,
+  ) async {
+    await _waitUntilEmittedAtLeast(
+      expectedStates.length,
+      expectedStates,
+      context,
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(_emittedStates, expectedStates, reason: context);
+  }
+
+  Future<void> cancel() => _subscription.cancel();
+
+  Future<void> _waitUntilEmittedAtLeast(
+    int expectedCount,
+    List<STATE> expectedStates,
+    String context,
+  ) async {
+    while (_emittedStates.length < expectedCount) {
+      _waiter ??= Completer<void>();
+      await _waiter!.future.timeout(
+        _stateStreamExpectationTimeout,
+        onTimeout: () {
+          fail(
+            '''
+$context
+expected emitted states: $expectedStates
+actual emitted states: $_emittedStates
+''',
+          );
+        },
+      );
+    }
+  }
+
+  void _completeWaiter() {
+    final waiter = _waiter;
+    if (waiter == null || waiter.isCompleted) {
+      return;
+    }
+    waiter.complete();
+    _waiter = null;
+  }
+}
+
+String _failureContext<STATE extends Object, ACTION extends Object>({
+  required STATE beforeState,
+  required ACTION action,
+  required String description,
+}) {
+  return '''
+StateMachine test failed.
+case: $description
+before: $beforeState
+action: $action
+''';
+}
+
+String _stateLabel(Object state) => state.toString();

--- a/lib/src/tester/state_machine_tester.dart
+++ b/lib/src/tester/state_machine_tester.dart
@@ -10,8 +10,12 @@ import 'package:dart_fsm/src/tester/tester_state_machine.dart';
 import 'package:test/test.dart';
 
 /// This class is used to test the state machine.
+///
+/// Use `runStateMachineTestCases` instead.
+@Deprecated('Use runStateMachineTestCases instead.')
 class StateMachineTester<STATE extends Object, ACTION extends Object> {
   /// Creates a state machine tester.
+  @Deprecated('Use runStateMachineTestCases instead.')
   StateMachineTester({
     required GraphBuilder<STATE, ACTION> graphBuilder,
     List<SideEffectCreator<STATE, ACTION, SideEffect>> sideEffectCreators =
@@ -82,8 +86,19 @@ class StateMachineTester<STATE extends Object, ACTION extends Object> {
 }
 
 /// This class is used to store the test case information.
+///
+/// Use `ifDispatched` with `transitionExpectationIs` or
+/// `expectInvalidTransition` instead.
+@Deprecated(
+  'Use ifDispatched with transitionExpectationIs or '
+  'expectInvalidTransition instead.',
+)
 final class SMAssertObject<S extends Object, A extends Object> {
   /// Creates a test case object.
+  @Deprecated(
+    'Use ifDispatched with transitionExpectationIs or '
+    'expectInvalidTransition instead.',
+  )
   const SMAssertObject({
     required this.action,
     this.afterState,

--- a/lib/src/tester/tester_state_machine.dart
+++ b/lib/src/tester/tester_state_machine.dart
@@ -8,9 +8,15 @@ import 'package:dart_fsm/src/state_machine/side_effect/side_effect_creator_inter
 import 'package:dart_fsm/src/state_machine/side_effect/side_effect_interface.dart';
 
 /// A state machine for testing.
+///
+/// Use a real StateMachine with `runStateMachineTestCases` instead.
+@Deprecated('Use a real StateMachine with runStateMachineTestCases instead.')
 class TesterStateMachine<STATE extends Object, ACTION extends Object>
     extends StateMachineImpl<STATE, ACTION> {
   /// Creates a state machine for testing.
+  @Deprecated(
+    'Use a real StateMachine with runStateMachineTestCases instead.',
+  )
   TesterStateMachine({
     required super.graphBuilder,
     required super.initialState,

--- a/test/state_machine_test_dsl_test.dart
+++ b/test/state_machine_test_dsl_test.dart
@@ -1,0 +1,186 @@
+// Copyright (c) 2024, teamLab inc.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:dart_fsm/dart_fsm.dart';
+import 'package:dart_fsm/dart_fsm_test_tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  var isCaseActive = false;
+
+  runStateMachineTestCases<_State, _Action, _Dependencies>(
+    name: 'StateMachine test DSL',
+    createMocks: _Dependencies.new,
+    createStateMachine: (dependencies, initialState) {
+      expect(isCaseActive, isTrue);
+      return createStateMachine(
+        graphBuilder: _graph,
+        initialState: initialState,
+        sideEffectCreators: [_LoadSideEffectCreator(dependencies)],
+      );
+    },
+    states: const [
+      _Initial(),
+      _Loading(),
+      _Loaded(),
+    ],
+    actions: const [
+      _Load(),
+      _Complete(),
+    ],
+    cases: [
+      whenInitialStateIs(
+        const _Initial(),
+        actions: [
+          ifDispatched(
+            const _Load(),
+            then: transitionExpectationIs(
+              after: const _Loading(),
+              eventually: const _Loaded(),
+            ),
+            arrange: (dependencies) {
+              dependencies.loadedValue = 'loaded';
+            },
+            verify: (dependencies) {
+              expect(dependencies.loadedValue, 'loaded');
+              expect(dependencies.loadCallCount, 1);
+            },
+          ),
+          ifDispatched(
+            const _Complete(),
+            then: expectInvalidTransition(),
+          ),
+        ],
+      ),
+      whenInitialStateIs(
+        const _Loading(),
+        actions: [
+          ifDispatched(
+            const _Load(),
+            then: expectInvalidTransition(),
+          ),
+          ifDispatched(
+            const _Complete(),
+            then: transitionExpectationIs(after: const _Loaded()),
+          ),
+        ],
+      ),
+      whenInitialStateIs(
+        const _Loaded(),
+        actions: [
+          ifDispatched(
+            const _Load(),
+            then: expectInvalidTransition(),
+          ),
+          ifDispatched(
+            const _Complete(),
+            then: expectInvalidTransition(),
+          ),
+        ],
+      ),
+    ],
+    beforeEach: () {
+      expect(isCaseActive, isFalse);
+      isCaseActive = true;
+    },
+    afterEach: () {
+      expect(isCaseActive, isTrue);
+      isCaseActive = false;
+    },
+  );
+}
+
+sealed class _State {
+  const _State();
+}
+
+final class _Initial extends _State {
+  const _Initial();
+
+  @override
+  String toString() => 'Initial';
+}
+
+final class _Loading extends _State {
+  const _Loading();
+
+  @override
+  String toString() => 'Loading';
+}
+
+final class _Loaded extends _State {
+  const _Loaded();
+
+  @override
+  String toString() => 'Loaded';
+}
+
+sealed class _Action {
+  const _Action();
+}
+
+final class _Load extends _Action {
+  const _Load();
+
+  @override
+  String toString() => 'Load';
+}
+
+final class _Complete extends _Action {
+  const _Complete();
+
+  @override
+  String toString() => 'Complete';
+}
+
+final _graph = GraphBuilder<_State, _Action>()
+  ..state<_Initial>(
+    (builder) => builder
+      ..on<_Load>(
+        (state, action) => builder.transitionTo(const _Loading()),
+      ),
+  )
+  ..state<_Loading>(
+    (builder) => builder
+      ..on<_Complete>(
+        (state, action) => builder.transitionTo(const _Loaded()),
+      ),
+  );
+
+final class _Dependencies {
+  String? loadedValue;
+  int loadCallCount = 0;
+
+  Future<void> load() async {
+    loadCallCount++;
+    await Future<void>.delayed(Duration.zero);
+  }
+}
+
+final class _LoadSideEffectCreator
+    implements AfterSideEffectCreator<_State, _Action, _LoadSideEffect> {
+  const _LoadSideEffectCreator(this.dependencies);
+
+  final _Dependencies dependencies;
+
+  @override
+  _LoadSideEffect? create(_State prevState, _Action action) {
+    return switch (action) {
+      _Load() => _LoadSideEffect(dependencies),
+      _Complete() => null,
+    };
+  }
+}
+
+final class _LoadSideEffect implements AfterSideEffect<_State, _Action> {
+  const _LoadSideEffect(this.dependencies);
+
+  final _Dependencies dependencies;
+
+  @override
+  Future<void> execute(StateMachine<_State, _Action> stateMachine) async {
+    await dependencies.load();
+    stateMachine.dispatch(const _Complete());
+  }
+}

--- a/test/state_machine_test_dsl_test.dart
+++ b/test/state_machine_test_dsl_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 
 void main() {
   var isCaseActive = false;
+  var hasCompletedAsyncVerify = true;
 
   runStateMachineTestCases<_State, _Action, _Dependencies>(
     name: 'StateMachine test DSL',
@@ -39,12 +40,16 @@ void main() {
               after: const _Loading(),
               eventually: const _Loaded(),
             ),
-            arrange: (dependencies) {
+            arrange: (dependencies) async {
+              await Future<void>.delayed(Duration.zero);
               dependencies.loadedValue = 'loaded';
+              hasCompletedAsyncVerify = false;
             },
-            verify: (dependencies) {
+            verify: (dependencies) async {
+              await Future<void>.delayed(Duration.zero);
               expect(dependencies.loadedValue, 'loaded');
               expect(dependencies.loadCallCount, 1);
+              hasCompletedAsyncVerify = true;
             },
           ),
           ifDispatched(
@@ -82,10 +87,12 @@ void main() {
     ],
     beforeEach: () {
       expect(isCaseActive, isFalse);
+      expect(hasCompletedAsyncVerify, isTrue);
       isCaseActive = true;
     },
     afterEach: () {
       expect(isCaseActive, isTrue);
+      expect(hasCompletedAsyncVerify, isTrue);
       isCaseActive = false;
     },
   );
@@ -153,6 +160,9 @@ final class _Dependencies {
   int loadCallCount = 0;
 
   Future<void> load() async {
+    if (loadedValue == null) {
+      throw StateError('load called before arrange completed');
+    }
     loadCallCount++;
     await Future<void>.delayed(Duration.zero);
   }


### PR DESCRIPTION
# Pull Request Description

This pull request adds a declarative test DSL for `StateMachine` transitions. The new API expresses tests in a Given-When-Then style, runs each case against a fresh production `StateMachine`, and verifies both immediate and asynchronous state transitions through `stateStream`.

The DSL keeps external dependency setup and verification separate from transition expectations, while requiring the tested state/action matrix to be explicit. The existing tester APIs remain available for compatibility but are now deprecated with migration guidance.

## Related Issues

None.

## Changes Proposed

1. Add and export the new StateMachine test DSL:
   - `runStateMachineTestCases`
   - `whenInitialStateIs`
   - `ifDispatched`
   - `transitionExpectationIs`
   - `expectInvalidTransition`
2. Verify immediate states, eventual states, and ordered `stateStream` emissions using a real `StateMachine`.
3. Register a coverage test that detects missing or unexpected entries in the declared `states x actions` matrix.
4. Support asynchronous `arrange` and `verify` callbacks with `FutureOr<void>`, and wait for them before continuing.
5. Ensure `afterEach` runs even when setup, execution, stream cancellation, or StateMachine cleanup fails.
6. Deprecate `StateMachineTester`, `SMAssertObject`, and `TesterStateMachine` with guidance toward the new DSL.
7. Add English and Japanese documentation and integration tests for the new API.

## Testing Checklist

- [x] Run `dart format --output=none --set-exit-if-changed .`
- [x] Run `dart analyze` with no errors (the existing example still reports two `avoid_print` info messages)
- [x] Run `dart test` with all 32 tests passing
- [x] Run `dart doc --dry-run` with no warnings or errors
- [x] Run `dart pub publish --dry-run` with no warnings
- [x] Verify compatibility with Dart 3.4.4, the package's minimum supported SDK line

## Checklist

- [x] Code follows the project's coding style
- [x] Documentation has been updated
- [x] Tests have been added for the new functionality
- [x] Existing tests continue to pass
- [x] Deprecated APIs remain available for backward compatibility

## Additional Comments

The StateMachine interface does not currently expose an idle or side-effect completion signal. The state stream probe therefore retains the existing 100 ms timeout and microtask-based observation behavior. Strict detection of later, unexpected emissions remains a possible future enhancement that would require a broader StateMachine interface design.

Multiple cases for the same action are intentionally supported so tests can describe different arranged outcomes, such as successful and failed side effects.

---
_This project is licensed under the [BSD-3-Clause License](../LICENSE)._